### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Unitale - Lua moddable Undertale engine
+# Unitale - Lua moddable Undertale engine
 
 Welcome to the Git repository for Unitale! In the coming week, a more detailed write-up about open sourcing will be done.
 
 In the meantime, you'll want to load the ModSelect scene from the Scenes folder. In the Battle scene, a script is attached to the Main Camera for loading a mod immediately from within the scene.
 
-##Required files
+## Required files
 
 To be able to run Unitale you'll need the default Undertale assets. The default Undertale assets are by Toby Fox (http://www.undertale.com) and used with permission.
 The files from this .zip should be unpacked to the Assets folder of the project.
 
 http://www.mediafire.com/download/6cfsv7pggfodcwx/Undertale_Assets_and_Example_Mods.zip
 
-##Licenses
+## Licenses
 
 Unitale is released under the GNU General Public License 3.0.
 We are using MoonSharp as our Lua interpreter, written by Marco Mastropaolo. The binary is included in /Assets/Plugins. License details in MOONSHARP_LICENSE.


### PR DESCRIPTION
GitHub requires a space after `#` in order to display titles correctly.